### PR TITLE
Move to a newer mongodb driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ clokwerk = "0.3"
 futures = "0.3"
 lazy_static = "1.4"
 log = "0.4"
+mongodb = { version = "1.1.0", default_features = false, features = ["sync"] }
 schemars = { version = "0.8.0-alpha-4", features = ["preserve_order", "chrono"] }
 okapi = { version = "0.5.0-alpha-1" }
 rayon = "1.4.0"
@@ -28,7 +29,4 @@ approx = "0.3"
 [dependencies.rocket_contrib]
 version = "0.4.3"
 default-features = false
-features = ["json", "mongodb_pool"]
-
-[dependencies.mongodb]
-version = "0.3.12"
+features = ["json", "databases"]

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,2 +1,2 @@
 [global.databases]
-wallet = { url = "mongodb://localhost:27017/wallet" }
+wallet = { url = "mongodb://localhost:27017" }

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -15,7 +15,7 @@ pub struct Broker {
     cnpj: Option<String>,
 }
 
-impl<'de> Queryable<'de> for Broker {
+impl Queryable for Broker {
     fn collection_name() -> &'static str {
         "brokers"
     }
@@ -26,8 +26,8 @@ impl<'de> Queryable<'de> for Broker {
 /// Adds a new broker
 #[openapi]
 #[post("/brokers", data = "<broker>")]
-pub fn add_broker(db: WalletDB, broker: Json<Broker>) -> WalletResult<Json<Broker>> {
-    api_add(db, broker)
+pub fn add_broker(broker: Json<Broker>) -> WalletResult<Json<Broker>> {
+    api_add(broker)
 }
 
 /// # List brokers
@@ -35,11 +35,8 @@ pub fn add_broker(db: WalletDB, broker: Json<Broker>) -> WalletResult<Json<Broke
 /// Lists all brokers
 #[openapi]
 #[get("/brokers?<options..>")]
-pub fn get_brokers(
-    db: WalletDB,
-    options: Option<Form<ListingOptions>>,
-) -> WalletResult<Rest<Json<Vec<Broker>>>> {
-    api_get::<Broker>(db, options)
+pub fn get_brokers(options: Option<Form<ListingOptions>>) -> WalletResult<Rest<Json<Vec<Broker>>>> {
+    api_get::<Broker>(options)
 }
 
 /// # Get broker
@@ -47,8 +44,8 @@ pub fn get_brokers(
 /// Get a specific broker
 #[openapi]
 #[get("/brokers/<oid>")]
-pub fn get_broker_by_oid(db: WalletDB, oid: String) -> WalletResult<Json<Broker>> {
-    api_get_one::<Broker>(db, oid)
+pub fn get_broker_by_oid(oid: String) -> WalletResult<Json<Broker>> {
+    api_get_one::<Broker>(oid)
 }
 
 /// # Update a broker
@@ -56,12 +53,8 @@ pub fn get_broker_by_oid(db: WalletDB, oid: String) -> WalletResult<Json<Broker>
 /// Update a specific broker
 #[openapi]
 #[put("/brokers/<oid>", data = "<broker>")]
-pub fn update_broker_by_oid(
-    db: WalletDB,
-    oid: String,
-    broker: Json<Broker>,
-) -> WalletResult<Json<Broker>> {
-    api_update::<Broker>(db, oid, broker)
+pub fn update_broker_by_oid(oid: String, broker: Json<Broker>) -> WalletResult<Json<Broker>> {
+    api_update::<Broker>(oid, broker)
 }
 
 /// # Delete a broker
@@ -69,6 +62,6 @@ pub fn update_broker_by_oid(
 /// Delete a specific broker
 #[openapi]
 #[delete("/brokers/<oid>")]
-pub fn delete_broker_by_oid(db: WalletDB, oid: String) -> WalletResult<Json<Broker>> {
-    api_delete::<Broker>(db, oid)
+pub fn delete_broker_by_oid(oid: String) -> WalletResult<Json<Broker>> {
+    api_delete::<Broker>(oid)
 }

--- a/src/historical/test.rs
+++ b/src/historical/test.rs
@@ -3,11 +3,7 @@ use crate::historical::{AssetDay, Historical};
 use chrono::{Date, Utc};
 
 impl Historical {
-    pub fn get_for_day_with_fallback(
-        _wallet: &mongodb::db::Database,
-        symbol: &str,
-        date: Date<Utc>,
-    ) -> WalletResult<AssetDay> {
+    pub fn get_for_day_with_fallback(symbol: &str, date: Date<Utc>) -> WalletResult<AssetDay> {
         let asset_day = AssetDay {
             symbol: symbol.to_string(),
             time: date.and_hms(13, 0, 0),

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1,11 +1,10 @@
 use chrono::{DateTime, Local};
-use mongodb::db::ThreadedDatabase;
 use rocket_okapi::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
 use crate::error::{BackendError, WalletResult};
-use crate::walletdb::Queryable;
+use crate::walletdb::{Queryable, WalletDB};
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
@@ -47,7 +46,7 @@ pub struct BaseOperation {
     pub portfolio: String,
 }
 
-impl<'de> Queryable<'de> for BaseOperation {
+impl Queryable for BaseOperation {
     fn collection_name() -> &'static str {
         "operations"
     }
@@ -61,8 +60,9 @@ fn default_portfolio() -> String {
     "default".to_string()
 }
 
-pub fn get_distinct_symbols(wallet: &mongodb::db::Database) -> WalletResult<Vec<String>> {
-    let collection = wallet.collection("operations");
+pub fn get_distinct_symbols() -> WalletResult<Vec<String>> {
+    let db = WalletDB::get_connection();
+    let collection = db.collection("operations");
 
     let symbols = collection
         .distinct("symbol", None, None)

--- a/src/portfolio.rs
+++ b/src/portfolio.rs
@@ -3,10 +3,9 @@ use rocket_okapi::openapi;
 
 use crate::error::WalletResult;
 use crate::position::Position;
-use crate::walletdb::WalletDB;
 
 #[openapi]
 #[post("/portfolio/position")]
-pub fn portfolio_position(db: WalletDB) -> WalletResult<Json<Vec<Position>>> {
-    Position::calculate_all(&*db).map(Json)
+pub fn portfolio_position() -> WalletResult<Json<Vec<Position>>> {
+    Position::calculate_all().map(Json)
 }

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -7,7 +7,6 @@ use std::sync::Mutex;
 
 use crate::historical::Historical;
 use crate::position::Position;
-use crate::walletdb::WalletDB;
 
 pub struct LockMap(HashSet<(String, String)>);
 lazy_static! {
@@ -75,19 +74,17 @@ impl Fairing for Scheduler {
         }
     }
 
-    fn on_launch(&self, rocket: &Rocket) {
-        let db = WalletDB::get_one(&rocket).expect("Could not get DB connection");
-
+    fn on_launch(&self, _: &Rocket) {
         std::thread::spawn(move || {
             info!("=> Starting on-launch full refresh…");
 
-            if let Err(e) = Historical::refresh_all(&db) {
+            if let Err(e) = Historical::refresh_all() {
                 warn!("failed to pre-calculate historicals: {:?}", e);
             }
 
             info!("=> Done refreshing historicals…");
 
-            if let Err(e) = Position::calculate_all(&db) {
+            if let Err(e) = Position::calculate_all() {
                 warn!("failed to pre-calculate positions: {:?}", e);
             }
 

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -22,7 +22,7 @@ pub struct StockOperation {
     pub operation: BaseOperation,
 }
 
-impl<'de> Queryable<'de> for StockOperation {
+impl Queryable for StockOperation {
     fn collection_name() -> &'static str {
         "operations"
     }
@@ -33,11 +33,8 @@ impl<'de> Queryable<'de> for StockOperation {
 /// Adds a new stock operation
 #[openapi]
 #[post("/stocks/operations", data = "<operation>")]
-pub fn add_stock_operation(
-    db: WalletDB,
-    operation: Json<StockOperation>,
-) -> WalletResult<Json<StockOperation>> {
-    api_add(db, operation)
+pub fn add_stock_operation(operation: Json<StockOperation>) -> WalletResult<Json<StockOperation>> {
+    api_add::<StockOperation>(operation)
 }
 
 /// # List stock operations
@@ -46,11 +43,10 @@ pub fn add_stock_operation(
 #[openapi]
 #[get("/stocks/operations?<options..>")]
 pub fn get_stock_operations(
-    db: WalletDB,
     options: Option<Form<ListingOptions>>,
 ) -> WalletResult<Rest<Json<Vec<StockOperation>>>> {
     println!("options: {:?}", options);
-    api_get::<StockOperation>(db, options)
+    api_get::<StockOperation>(options)
 }
 
 /// # Get stock operation
@@ -58,8 +54,8 @@ pub fn get_stock_operations(
 /// Get a specific stock operation
 #[openapi]
 #[get("/stocks/operations/<oid>")]
-pub fn get_stock_operation_by_oid(db: WalletDB, oid: String) -> WalletResult<Json<StockOperation>> {
-    api_get_one::<StockOperation>(db, oid)
+pub fn get_stock_operation_by_oid(oid: String) -> WalletResult<Json<StockOperation>> {
+    api_get_one::<StockOperation>(oid)
 }
 
 /// # Update a stock operation
@@ -68,11 +64,10 @@ pub fn get_stock_operation_by_oid(db: WalletDB, oid: String) -> WalletResult<Jso
 #[openapi]
 #[put("/stocks/operations/<oid>", data = "<operation>")]
 pub fn update_stock_operation_by_oid(
-    db: WalletDB,
     oid: String,
     operation: Json<StockOperation>,
 ) -> WalletResult<Json<StockOperation>> {
-    api_update::<StockOperation>(db, oid, operation)
+    api_update::<StockOperation>(oid, operation)
 }
 
 /// # Delete a stock operation
@@ -80,11 +75,8 @@ pub fn update_stock_operation_by_oid(
 /// Delete a specific stock operation
 #[openapi]
 #[delete("/stocks/operations/<oid>")]
-pub fn delete_stock_operation_by_oid(
-    db: WalletDB,
-    oid: String,
-) -> WalletResult<Json<StockOperation>> {
-    api_delete::<StockOperation>(db, oid)
+pub fn delete_stock_operation_by_oid(oid: String) -> WalletResult<Json<StockOperation>> {
+    api_delete::<StockOperation>(oid)
 }
 
 /// # Get a stock position
@@ -92,6 +84,6 @@ pub fn delete_stock_operation_by_oid(
 /// Get position for a specific stock
 #[openapi]
 #[get("/stocks/position/<symbol>")]
-pub fn get_stock_position_by_symbol(db: WalletDB, symbol: String) -> WalletResult<Json<Position>> {
-    Position::calculate_for_symbol(&*db, &symbol).map(Json)
+pub fn get_stock_position_by_symbol(symbol: String) -> WalletResult<Json<Position>> {
+    Position::calculate_for_symbol(&symbol).map(Json)
 }

--- a/src/walletdb.rs
+++ b/src/walletdb.rs
@@ -1,42 +1,74 @@
-use mongodb::coll::options::FindOptions;
-use mongodb::db::ThreadedDatabase;
-use mongodb::ThreadedClient;
-use mongodb::{bson, doc, Bson};
-use rocket_contrib::database;
-use rocket_contrib::databases::mongodb;
-use serde::{Deserialize, Serialize};
-use std::fmt;
+use mongodb::bson::{doc, from_bson, oid, spec, to_bson, Bson, Document};
+use mongodb::options::FindOptions;
+use mongodb::sync::{Client, Cursor, Database};
+use rocket::fairing::{Fairing, Info, Kind};
+use rocket::Rocket;
+use rocket_contrib::databases::database_config;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::cell::RefCell;
+use std::sync::Mutex;
 
 use crate::error::{BackendError, WalletResult};
 
-#[database("wallet")]
-pub struct WalletDB(mongodb::db::Database);
-
-// Had to implement this manually as derive was not being picked up?
-impl fmt::Debug for WalletDB {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
+lazy_static! {
+    static ref WALLET_CLIENT: Mutex<RefCell<Option<Client>>> = Mutex::new(RefCell::new(None));
 }
 
-impl WalletDB {
-    pub fn get_connection() -> mongodb::db::Database {
-        // FIXME: use the same configuration as we have for the pool.
-        let db_client = mongodb::Client::with_uri("mongodb://127.0.0.1:27017/")
-            .expect("Could not connect to mongodb");
+#[derive(Debug)]
+pub struct WalletDB {}
 
+impl WalletDB {
+    pub fn fairing() -> Self {
+        WalletDB {}
+    }
+
+    pub fn init_client(uri: &str) {
+        WALLET_CLIENT.lock().unwrap().replace(Some(
+            Client::with_uri_str(uri).expect("Failed to connect to mongodb"),
+        ));
+    }
+
+    pub fn get_connection() -> Database {
         if cfg!(test) {
-            db_client.db("wallet-fake-test")
+            WALLET_CLIENT
+                .lock()
+                .unwrap()
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .database("wallet-fake-test")
         } else {
-            db_client.db("wallet")
+            WALLET_CLIENT
+                .lock()
+                .unwrap()
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .database("wallet")
         }
     }
 }
 
-pub trait Queryable<'de>: Serialize + Deserialize<'de> + std::fmt::Debug {
+impl Fairing for WalletDB {
+    fn info(&self) -> Info {
+        Info {
+            name: "WalletDB",
+            kind: Kind::Launch,
+        }
+    }
+
+    fn on_launch(&self, rocket: &Rocket) {
+        let database = database_config("wallet", rocket.config())
+            .expect("Did not find database configuration in Rocket.toml");
+        Self::init_client(database.url);
+    }
+}
+
+pub trait Queryable: Serialize + DeserializeOwned + std::fmt::Debug {
     fn collection_name() -> &'static str;
 
-    fn from_docs(cursor: mongodb::cursor::Cursor) -> WalletResult<Vec<Self>> {
+    fn from_docs(cursor: Cursor) -> WalletResult<Vec<Self>> {
         cursor
             .map(|result| match result {
                 Ok(doc) => Self::from_doc(doc),
@@ -45,7 +77,7 @@ pub trait Queryable<'de>: Serialize + Deserialize<'de> + std::fmt::Debug {
             .collect::<WalletResult<Vec<Self>>>()
     }
 
-    fn from_doc(doc: mongodb::ordered::OrderedDocument) -> WalletResult<Self> {
+    fn from_doc(doc: Document) -> WalletResult<Self> {
         // Since I don't want to rename the id field to keep the REST API pretty,
         // I need to do some surgery here. Note that some models, like Broker, use
         // slugs as their IDs instead of ObjectIds, so we need to handle the two
@@ -54,28 +86,28 @@ pub trait Queryable<'de>: Serialize + Deserialize<'de> + std::fmt::Debug {
         if let Some(id) = doc.remove("_id") {
             match id.as_object_id() {
                 Some(id) => doc.insert(String::from("id"), id.to_string()),
-                None => doc.insert_bson(String::from("id"), id),
+                None => doc.insert(String::from("id"), id),
             };
         }
 
-        match bson::from_bson(Bson::Document(doc)) {
+        match from_bson(Bson::Document(doc)) {
             Ok(obj) => Ok(obj),
             Err(e) => Err(dang!(Bson, e)),
         }
     }
 
-    fn to_doc(&self) -> WalletResult<mongodb::ordered::OrderedDocument> {
+    fn to_doc(&self) -> WalletResult<Document> {
         // Reverse surgery (see above) on the id, to rename it properly. Do we need to handle
         // models with ObjectId at all?
-        fn fix_id(doc: &mut mongodb::ordered::OrderedDocument) {
+        fn fix_id(doc: &mut Document) {
             if let Some(id) = doc.remove("id") {
-                if id.element_type() != bson::spec::ElementType::NullValue {
-                    doc.insert_bson(String::from("_id"), id);
+                if id.element_type() != spec::ElementType::Null {
+                    doc.insert(String::from("_id"), id);
                 }
             }
         }
 
-        match bson::to_bson(self) {
+        match to_bson(self) {
             Ok(doc) => match doc {
                 Bson::Document(mut doc) => {
                     fix_id(&mut doc);
@@ -88,13 +120,11 @@ pub trait Queryable<'de>: Serialize + Deserialize<'de> + std::fmt::Debug {
     }
 }
 
-pub fn get<'de, T>(
-    wallet: &mongodb::db::Database,
-    options: Option<FindOptions>,
-) -> WalletResult<Vec<T>>
+pub fn get<T>(options: Option<FindOptions>) -> WalletResult<Vec<T>>
 where
-    T: Queryable<'de>,
+    T: Queryable,
 {
+    let wallet = WalletDB::get_connection();
     let cursor = match wallet.collection(T::collection_name()).find(None, options) {
         Ok(cursor) => cursor,
         Err(e) => return Err(dang!(Database, e)),
@@ -102,33 +132,28 @@ where
     T::from_docs(cursor)
 }
 
-pub fn get_count<'de, T>(wallet: &mongodb::db::Database) -> WalletResult<i64>
+pub fn get_count<T>() -> WalletResult<i64>
 where
-    T: Queryable<'de>,
+    T: Queryable,
 {
+    let wallet = WalletDB::get_connection();
     wallet
         .collection(T::collection_name())
-        .count(None, None)
+        .count_documents(None, None)
         .map_err(|e| dang!(Database, e))
 }
 
-fn string_to_objectid(oid: &str) -> Result<bson::oid::ObjectId, bson::oid::Error> {
-    bson::oid::ObjectId::with_string(oid)
+fn string_to_objectid(oid: &str) -> Result<oid::ObjectId, oid::Error> {
+    oid::ObjectId::with_string(oid)
 }
 
-fn objectid_to_string(oid: Option<bson::Bson>) -> WalletResult<String> {
-    let oid = oid.ok_or_else(|| {
-        dang!(
-            Bson,
-            "Tried to use None as ObjectId when converting to String"
-        )
-    })?;
+fn objectid_to_string(oid: Bson) -> WalletResult<String> {
     oid.as_object_id()
         .map(|oid| oid.to_string())
         .ok_or_else(|| dang!(Bson, format!("Could not convert {:?} to String", oid)))
 }
 
-fn filter_from_oid(oid: &str) -> bson::ordered::OrderedDocument {
+fn filter_from_oid(oid: &str) -> Document {
     if let Ok(object_id) = string_to_objectid(oid) {
         doc! {"_id": object_id}
     } else {
@@ -136,10 +161,11 @@ fn filter_from_oid(oid: &str) -> bson::ordered::OrderedDocument {
     }
 }
 
-pub fn get_one<'de, T>(wallet: &mongodb::db::Database, oid: String) -> WalletResult<T>
+pub fn get_one<T>(oid: String) -> WalletResult<T>
 where
-    T: Queryable<'de>,
+    T: Queryable,
 {
+    let wallet = WalletDB::get_connection();
     match wallet
         .collection(T::collection_name())
         .find_one(Some(filter_from_oid(&oid)), None)
@@ -149,9 +175,9 @@ where
     }
 }
 
-pub fn insert_one<'de, T>(wallet: &mongodb::db::Database, obj: T) -> WalletResult<T>
+pub fn insert_one<T>(obj: T) -> WalletResult<T>
 where
-    T: Queryable<'de>,
+    T: Queryable,
 {
     let mut doc = T::to_doc(&obj)?;
 
@@ -159,39 +185,42 @@ where
     // so ignore if any comes along with the request.
     doc.remove("_id");
 
+    let wallet = WalletDB::get_connection();
     match wallet
         .collection(T::collection_name())
         .insert_one(doc, None)
     {
-        Ok(result) => get_one(wallet, objectid_to_string(result.inserted_id)?),
+        Ok(result) => get_one(objectid_to_string(result.inserted_id)?),
         Err(e) => Err(dang!(Database, e)),
     }
 }
 
-pub fn update_one<'de, T>(wallet: &mongodb::db::Database, oid: String, obj: T) -> WalletResult<T>
+pub fn update_one<T>(oid: String, obj: T) -> WalletResult<T>
 where
-    T: Queryable<'de>,
+    T: Queryable,
 {
     let mut doc = T::to_doc(&obj)?;
 
     // $set doesn't seem to like getting data with _id, so we remove it.
     doc.remove("_id");
 
+    let wallet = WalletDB::get_connection();
     match wallet.collection(T::collection_name()).update_one(
         filter_from_oid(&oid),
         doc! {"$set": doc},
         None,
     ) {
-        Ok(_) => get_one(wallet, oid),
+        Ok(_) => get_one(oid),
         Err(e) => Err(dang!(Database, e)),
     }
 }
 
-pub fn delete_one<'de, T>(wallet: &mongodb::db::Database, oid: String) -> WalletResult<T>
+pub fn delete_one<T>(oid: String) -> WalletResult<T>
 where
-    T: Queryable<'de>,
+    T: Queryable,
 {
-    let result = get_one::<T>(wallet, oid.clone())?;
+    let result = get_one::<T>(oid.clone())?;
+    let wallet = WalletDB::get_connection();
     match wallet
         .collection(T::collection_name())
         .delete_one(filter_from_oid(&oid), None)


### PR DESCRIPTION
Use a module-global static to hold the client, and initialize it on
startup. This allows any code to obtain a connection from the same
client regardless of being on the path of a Rocket endpoint or not.

Closes #9.