### PR TITLE
Use temporary db with random name for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rocket_okapi = { version = "0.6.0-alpha-1" }
 rocket = { version = "0.4.3", default-features = false }
 serde = "1.0"
 tokio = { version = "0.2", features = ["full"] }
+uuid = { version = "0.8", features = ["v4"] }
 yahoo-finance = { git = "https://github.com/kov/yahoo-finance-rs.git" }
 
 [dev-dependencies]

--- a/src/historical.rs
+++ b/src/historical.rs
@@ -283,5 +283,9 @@ mod tests {
             .count_documents(None, None)
             .expect("Count failed");
         assert_eq!(count, original_count);
+
+        if let Err(e) = db.drop(None) {
+            println!("Failed to drop test db {}", format!("{:?}", e));
+        }
     }
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -445,5 +445,9 @@ mod tests {
             assert_relative_eq!(*realized, position.realized);
             assert_relative_eq!(*gain, position.gain);
         }
+
+        if let Err(e) = db.drop(None) {
+            println!("Failed to drop test db {}", format!("{:?}", e));
+        }
     }
 }

--- a/src/walletdb.rs
+++ b/src/walletdb.rs
@@ -29,24 +29,29 @@ impl WalletDB {
         ));
     }
 
+    #[cfg(not(test))]
     pub fn get_connection() -> Database {
-        if cfg!(test) {
-            WALLET_CLIENT
-                .lock()
-                .unwrap()
-                .borrow()
-                .as_ref()
-                .unwrap()
-                .database("wallet-fake-test")
-        } else {
-            WALLET_CLIENT
-                .lock()
-                .unwrap()
-                .borrow()
-                .as_ref()
-                .unwrap()
-                .database("wallet")
+        WALLET_CLIENT
+            .lock()
+            .unwrap()
+            .borrow()
+            .as_ref()
+            .unwrap()
+            .database("wallet")
+    }
+
+    #[cfg(test)]
+    pub fn get_connection() -> Database {
+        lazy_static! {
+            static ref NAME: String = format!("wallet-fake-test-{}", uuid::Uuid::new_v4());
         }
+        WALLET_CLIENT
+            .lock()
+            .unwrap()
+            .borrow()
+            .as_ref()
+            .unwrap()
+            .database(&NAME)
     }
 }
 


### PR DESCRIPTION
Tests were breaking when more than one was running in parallel (which
happened fairly often on my environment due to them being run by both
cargo watch and git push, for one). This was due to the fact that they
used a single database.

Now each test runs using its own temporary database with a generated
random name. It would be much better to use an in-memory storage, but
mongo seems to only make that available for the enterprise version (doh).

Also, beware panics, as they will not allow the database to be dropped.
I could not find a good way of fixing that yet, as panic::catch_unwind()
doesn't seem to work.