### PR TITLE
Make tests more robust for github CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ yahoo-finance = { git = "https://github.com/kov/yahoo-finance-rs.git" }
 
 [dev-dependencies]
 approx = "0.3"
+rusty-fork = "0.3"
 
 [dependencies.rocket_contrib]
 version = "0.4.3"

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ run:
 	@cargo +nightly run
 
 test:
-	@RUST_BACKTRACE=1 cargo +nightly test -vv
+	@RUST_BACKTRACE=1 cargo +nightly test -vv -- --nocapture


### PR DESCRIPTION
I assumed initially that all tests ran as separate processes, which
is why they passed locally. Turns out they actually run as separate
threads on the same process, and that leads to a race.

If the position test ends in the middle of the historical one, or
vice-versa, the database that is being used by the test will get
dropped. Not a good thing to happen ;D

We now get each test to run on a separate process using rusty-fork,
and we also pass --nocapture to the test binary, so we can get any
println outputs as well.